### PR TITLE
Update locust, fix open files warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+.vscode
+
+*.swp
+package-lock.json
+.pytest_cache
+*.egg-info
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# CDK Context & Staging files
+.cdk.staging/
+cdk.out/

--- a/cdklocust/locust_container.py
+++ b/cdklocust/locust_container.py
@@ -36,6 +36,13 @@ class locustContainer(core.Construct):
             environment=container_env
         )
 
+        locust_container.add_ulimits(
+            ecs.Ulimit(
+                name=ecs.UlimitName.NOFILE,
+                soft_limit=65536,
+                hard_limit=65536
+            )
+        )
 
         web_port_mapping = ecs.PortMapping(container_port=8089)
         if role != "standalone":

--- a/cdklocust/locust_container.py
+++ b/cdklocust/locust_container.py
@@ -93,13 +93,15 @@ class locustContainer(core.Construct):
             self.lb = elbv2.ApplicationLoadBalancer(self, "LoustLB", vpc=vpc,
                                                     internet_facing=True
                                                    )
+            # Forward port 80 to port 8089
             listener = self.lb.add_listener("Listener", port=80)
             listener.add_targets("ECS1",
-                                 port=80,
+                                 port=8089,
+                                 protocol=elbv2.ApplicationProtocol.HTTP,
                                  targets=[locust_service]
-                                )
+                                 )
             core.CfnOutput(
                 self, "lburl",
                 description="URL for ALB fronting locust master",
-                value=self.lb.load_balancer_dns_name
-                )
+                value="http://{}".format(self.lb.load_balancer_dns_name)
+            )

--- a/locust/Dockerfile
+++ b/locust/Dockerfile
@@ -1,8 +1,5 @@
+FROM locustio/locust:1.0.3
 
-FROM locustio/locust:0.14.6
-
-ADD locustfile.py locustfile.py
-
-
-
-
+WORKDIR /home/locust
+COPY . .
+RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+-e .
+-r ./locust/requirements.txt
 aws-cdk.core
 aws-cdk.aws_ec2
 aws-cdk.aws_ecs


### PR DESCRIPTION
Thanks for creating your repo, it was very helpful!

When I updated to Locust 1.0.3, I noticed the open file warning (https://docs.locust.io/en/stable/installation.html#increasing-maximum-number-of-open-files-limit).  This change seems to fix it.